### PR TITLE
Add an .md5 reference for bins

### DIFF
--- a/multidoge-0.1.2-bins.md5
+++ b/multidoge-0.1.2-bins.md5
@@ -1,0 +1,3 @@
+a5788daf3b58b6a5efa222db9fd05367  multidoge-0.1.2.dmg
+a9484de0a99ada77ebd0118a33708c72  multidoge-0.1.2-linux.jar
+5083cb4f664cf3a62af292e54978ee39  multidoge-0.1.2-windows-setup.exe


### PR DESCRIPTION
This addresses #23 partially by providing a trusted md5 check file.
#23 will be resolved completely when multidoge.org, the main distribution site for the binaries generated here, has SSL.

While users could be fooled into downloading a malicious multibit binary, they can at least refer to this md5 check file, since it's stored in a secure location -- GitHub repos do require some kind of authentication, and are themselves always-SSL.
